### PR TITLE
Fixed bug not querying select token on board

### DIFF
--- a/fieldofclothofgold.js
+++ b/fieldofclothofgold.js
@@ -114,18 +114,7 @@ function (dojo, declare) {
                 this.playTileOnTable(player_id, tile.id, tile.stock_id);
             }
 
-            for ( var [space, arg] of Object.entries(this.gamedatas.board) )
-            {
-                if ( arg.player != null ) {
-                    // function( action_name, player_id, token_id )
-                    this.addTokenOnBoard(space, arg.player, arg.token);
-                }
-            }
-
-            console.log('just before placing tokens')
-
             // place tokens in player supplies
-            // var [space, arg] of Object.entries(this.gamedatas.board)
             for ( let [player, tokens] of Object.entries(this.gamedatas.tokens) )
             {
                 for ( let token of Object.values(tokens) ) {
@@ -140,7 +129,13 @@ function (dojo, declare) {
                 }
             }
 
-            console.log('survived placing tokens')
+            for ( var [space, arg] of Object.entries(this.gamedatas.board) )
+            {
+                if ( arg.player != null ) {
+                    // function( action_name, player_id, token_id )
+                    this.addTokenOnBoard(space, arg.player, arg.token);
+                }
+            }
 
             // dojo.query( 'tokens' ).connect( 'onclick', this, 'onMoveToken' );
 

--- a/fieldofclothofgold.js
+++ b/fieldofclothofgold.js
@@ -122,6 +122,26 @@ function (dojo, declare) {
                 }
             }
 
+            console.log('just before placing tokens')
+
+            // place tokens in player supplies
+            // var [space, arg] of Object.entries(this.gamedatas.board)
+            for ( let [player, tokens] of Object.entries(this.gamedatas.tokens) )
+            {
+                for ( let token of Object.values(tokens) ) {
+                    dojo.place( this.format_block( 'jstpl_token', {
+                        color: this.gamedatas.players[ player ].color,
+                        player_id: player,
+                        token_id: token.id
+                    } ) , 'tokens' );
+
+                    let token_selector = 'token_'+player+'_'+token.id;
+                    this.placeOnObject( token_selector, 'overall_player_board_'+player );
+                }
+            }
+
+            console.log('survived placing tokens')
+
             // dojo.query( 'tokens' ).connect( 'onclick', this, 'onMoveToken' );
 
             dojo.query( '.circle_action' ).connect( 'onclick', this, 'onPlaceToken' );
@@ -281,34 +301,17 @@ function (dojo, declare) {
         {
             console.log('in addTokenOnBoard')
 
-            dojo.place( this.format_block( 'jstpl_token', {
-                color: this.gamedatas.players[ player_id ].color,
-                player_id: player_id,
-                token_id: token_id
-            } ) , 'tokens' );
+            // dojo.place( this.format_block( 'jstpl_token', {
+            //     color: this.gamedatas.players[ player_id ].color,
+            //     player_id: player_id,
+            //     token_id: token_id
+            // } ) , 'tokens' );
             
             var token_selector = 'token_'+player_id+'_'+token_id;
 
-            this.placeOnObject( token_selector, 'overall_player_board_'+player_id );
+            // this.placeOnObject( token_selector, 'overall_player_board_'+player_id );
             this.slideToObject( token_selector, 'circle_action_'+action_name ).play();
         },
-
-        moveTokenOnBoard: function( action_name, player_id, token_id )
-        {
-            console.log('in moveTokenOnBoard')
-
-            dojo.place( this.format_block( 'jstpl_token', {
-                color: this.gamedatas.players[ player_id ].color,
-                player_id: player_id,
-                token_id: token_id
-            } ) , 'tokens' );
-            
-            var token_selector = 'token_'+player_id+'_'+token_id;
-
-            this.placeOnObject( token_selector, 'overall_player_board_'+player_id );
-            this.slideToObject( token_selector, 'circle_action_'+action_name ).play();
-        },
-
 
         ///////////////////////////////////////////////////
         //// Player's action


### PR DESCRIPTION
Once all tokens were placed on board, tokens were not selectable for movement until the page was refreshed.

Fixed this by allocating the CSS objects on setup and hiding them in player tableaus. This makes them query-able from setup (vs only after they are created and player refreshes to properly hook the elements)